### PR TITLE
Fixes ALKIS search functionality

### DIFF
--- a/qgisclasses.py
+++ b/qgisclasses.py
@@ -482,7 +482,7 @@ class ALKISSearch(QDialog, ALKISSearchBase):
 
         qry = QSqlQuery(db)
         if not qry.exec_("SELECT has_table_privilege('eigner', 'SELECT')") or not qry.next() or not qry.value(0):
-            self.tabWidget.removeTab(self.tabEigentuemer)
+            self.tabWidget.removeTab(self.tabWidget.indexOf(self.tabEigentuemer))
 
         self.replaceButton = self.buttonBox.addButton(u"Ersetzen", QDialogButtonBox.ActionRole)
         self.addButton = self.buttonBox.addButton(u"Hinzufügen", QDialogButtonBox.ActionRole)


### PR DESCRIPTION
In cases where grant privileges on owner information are not available, QGIS isn't able to invoke the ALKIS search form. The following exception is thrown:

Traceback (most recent call last):
			  File "XXX/.qgis2/python/plugins\alkisplugin\alkisplugin.py", line 1177, in search
			    dlg = ALKISSearch(self)
			  File "XXX/.qgis2/python/plugins\alkisplugin\qgisclasses.py", line 485, in __init__
			    self.tabWidget.removeTab(self.tabEigentuemer)
			TypeError: QTabWidget.removeTab(int): argument 1 has unexpected type 'QWidget'

Tab for owner search is now correctly removed from tab widget, using the expected int index.